### PR TITLE
fix typo introduced by reusing 'predict' in FFMGradient and FFMModel

### DIFF
--- a/src/main/scala/org/apache/spark/mllib/classification/FieldAwaredFactorizationMachine.scala
+++ b/src/main/scala/org/apache/spark/mllib/classification/FieldAwaredFactorizationMachine.scala
@@ -142,7 +142,7 @@ class FFMModel(val numFeatures: Int,
       }
       i += 1
     }
-    t
+    1 / (1 + math.exp(-t))
   }
 
   override protected def formatVersion: String = "1.0"


### PR DESCRIPTION
Signed-off-by: Vincent Xie <vincent.xie@intel.com>